### PR TITLE
Pass timestamp on message publish

### DIFF
--- a/samples/Venture/Common/Venture.Common.Poezd.Adapter.UnitTests/TestSubjects/FakeMessageRouter.cs
+++ b/samples/Venture/Common/Venture.Common.Poezd.Adapter.UnitTests/TestSubjects/FakeMessageRouter.cs
@@ -39,7 +39,8 @@ namespace Venture.Common.Poezd.Adapter.UnitTests.TestSubjects
       TMessage message,
       string correlationId = default,
       string causationId = default,
-      string messageId = default)
+      string messageId = default,
+      DateTimeOffset timestamp = default)
       where TMessage : class
     {
       Message = message;

--- a/sources/Eshva.Poezd.Core/Routing/IMessageRouter.cs
+++ b/sources/Eshva.Poezd.Core/Routing/IMessageRouter.cs
@@ -79,14 +79,17 @@ namespace Eshva.Poezd.Core.Routing
     /// <param name="message">
     /// The message to route.
     /// </param>
-    /// <param name="messageId">
-    /// The message ID that will be used in broker message headers.
-    /// </param>
     /// <param name="correlationId">
     /// The correlation ID that will be used in broker message headers.
     /// </param>
     /// <param name="causationId">
     /// The causation ID that will be used in broker message headers.
+    /// </param>
+    /// <param name="messageId">
+    /// The message ID that will be used in broker message headers.
+    /// </param>
+    /// <param name="timestamp">
+    /// Timestamp of the message in UTC.
     /// </param>
     /// <returns>
     /// A task that can be used for waiting the message routing finished.
@@ -99,7 +102,8 @@ namespace Eshva.Poezd.Core.Routing
       [NotNull] TMessage message,
       string correlationId = default,
       string causationId = default,
-      string messageId = default)
+      string messageId = default,
+      DateTimeOffset timestamp = default)
       where TMessage : class;
   }
 }

--- a/sources/Eshva.Poezd.Core/Routing/MessageRouter.cs
+++ b/sources/Eshva.Poezd.Core/Routing/MessageRouter.cs
@@ -130,7 +130,8 @@ namespace Eshva.Poezd.Core.Routing
       TMessage message,
       string correlationId = default,
       string causationId = default,
-      string messageId = default)
+      string messageId = default,
+      DateTimeOffset timestamp = default)
       where TMessage : class
     {
       var apis = _brokers.SelectMany(broker => broker.Egress.Apis).Where(api => api.MessageTypesRegistry.DoesOwn<TMessage>()).ToArray();
@@ -146,7 +147,8 @@ namespace Eshva.Poezd.Core.Routing
             Api = api,
             CorrelationId = correlationId,
             CausationId = causationId,
-            MessageId = messageId
+            MessageId = messageId,
+            Timestamp = timestamp
           };
 
           var pipeline = BuildEgressPipeline(_brokers.Single(broker => broker.Egress.Apis.Contains(api)), api);

--- a/tests/Eshva.Poezd.Core.UnitTests/TestSubjects/TestBrokerEgressDriver.cs
+++ b/tests/Eshva.Poezd.Core.UnitTests/TestSubjects/TestBrokerEgressDriver.cs
@@ -32,6 +32,7 @@ namespace Eshva.Poezd.Core.UnitTests.TestSubjects
 
     public Task Publish(MessagePublishingContext context, CancellationToken cancellationToken)
     {
+      _state.PublishingContext = context;
       _state.PublishedMessageCount++;
       return Task.CompletedTask;
     }

--- a/tests/Eshva.Poezd.Core.UnitTests/TestSubjects/TestDriverState.cs
+++ b/tests/Eshva.Poezd.Core.UnitTests/TestSubjects/TestDriverState.cs
@@ -1,6 +1,7 @@
 #region Usings
 
 using System.Collections.Generic;
+using Eshva.Poezd.Core.Routing;
 
 #endregion
 
@@ -17,5 +18,7 @@ namespace Eshva.Poezd.Core.UnitTests.TestSubjects
     public int DisposedCount { get; set; }
 
     public int PublishedMessageCount { get; set; }
+
+    public MessagePublishingContext PublishingContext { get; set; }
   }
 }

--- a/tests/Eshva.Poezd.Core.UnitTests/given_message_router_publishing_egress_messages.cs
+++ b/tests/Eshva.Poezd.Core.UnitTests/given_message_router_publishing_egress_messages.cs
@@ -92,15 +92,18 @@ namespace Eshva.Poezd.Core.UnitTests
       const string correlationId = "correlation ID";
       const string causationId = "causation ID";
       const string messageId = "message ID";
+      var timestamp = DateTimeOffset.UtcNow;
       await messageRouter.RouteEgressMessage(
         new TestEgressMessage1(),
         correlationId,
         causationId,
-        messageId);
+        messageId,
+        timestamp);
 
       state.PublishingContext.CorrelationId.Should().Be(correlationId);
       state.PublishingContext.CausationId.Should().Be(causationId);
       state.PublishingContext.MessageId.Should().Be(messageId);
+      state.PublishingContext.Timestamp.Should().Be(timestamp);
     }
 
     private readonly ITestOutputHelper _testOutputHelper;

--- a/tests/Eshva.Poezd.Core.UnitTests/given_message_router_publishing_egress_messages.cs
+++ b/tests/Eshva.Poezd.Core.UnitTests/given_message_router_publishing_egress_messages.cs
@@ -79,6 +79,30 @@ namespace Eshva.Poezd.Core.UnitTests
         .Where(exception => exception.Message.Contains("message publishing"), "exception in a step should break publishing");
     }
 
+    [Fact]
+    public async Task when_publish_with_all_parameters_it_should_pass_them_to_driver()
+    {
+      var state = new TestDriverState();
+      await using var container = RoutingTests
+        .SetupContainer(_testOutputHelper)
+        .AddRouterWithConfiguredEgressApi(state);
+      var messageRouter = container.GetMessageRouter();
+      await messageRouter.Start();
+
+      const string correlationId = "correlation ID";
+      const string causationId = "causation ID";
+      const string messageId = "message ID";
+      await messageRouter.RouteEgressMessage(
+        new TestEgressMessage1(),
+        correlationId,
+        causationId,
+        messageId);
+
+      state.PublishingContext.CorrelationId.Should().Be(correlationId);
+      state.PublishingContext.CausationId.Should().Be(causationId);
+      state.PublishingContext.MessageId.Should().Be(messageId);
+    }
+
     private readonly ITestOutputHelper _testOutputHelper;
   }
 }


### PR DESCRIPTION
The message router should pass timestamp into context on message publishing.